### PR TITLE
Optimize broadcast indexing with precomputed strides

### DIFF
--- a/src/numeric/tests/base/test_expression_base.cpp
+++ b/src/numeric/tests/base/test_expression_base.cpp
@@ -515,7 +515,7 @@ TEST_F(ExpressionBaseTest, LazyEvaluationNoTemporaries) {
 
     // Expression should be lightweight - just storing references
     // The size of the expression object should be small regardless of data size
-    EXPECT_LT(sizeof(expr), 200);  // Expression metadata should be small
+    EXPECT_LT(sizeof(expr), 300);  // Expression metadata should be small
 
     // No evaluation should have happened yet
     // We can verify this by checking that we can still modify the source data


### PR DESCRIPTION
## Summary
- eliminate per-eval heap allocations by precomputing broadcast strides in `BinaryExpression`
- adjust expression tests for updated object size

## Testing
- `cmake -S src/numeric -B build_numeric -DFEM_NUMERIC_BUILD_TESTS=ON`
- `cmake --build build_numeric`
- `cd build_numeric && ctest`
- `g++ -std=c++20 -Isrc/numeric/include /tmp/broadcast_bench.cpp -ltbb -o /tmp/broadcast_bench`
- `/tmp/broadcast_bench`

------
https://chatgpt.com/codex/tasks/task_e_68bf6fe4d6448323b86b40e67a7c4b8e