### PR TITLE
Add optional oneTBB fetch support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option (BUNDLED_MPI             "Build our own MPI"                        OFF)
 option (WARNINGS_AS_ERRORS      "Treat warnings as errors"                 ON)
 option (BUILD_UNIT_TESTS        "Build unit tests"                         ON)
 option (BUILD_PERFORMANCE_TESTS "Build Catch2 micro-benchmarks"            ON)
+option (TBB_FETCH              "Automatically download oneTBB if missing" ON)
 # -----------------------------------------------------------------------------
 #  Compiler & language standard
 # -----------------------------------------------------------------------------
@@ -90,6 +91,7 @@ target_include_directories(femsolver_options INTERFACE
 #  Third-party header-only deps via FetchContent
 # -----------------------------------------------------------------------------
 include(FetchContent)
+include(cmake/FetchTBB.cmake)
 
 # Catch2 (tests)
 if (BUILD_UNIT_TESTS OR BUILD_PERFORMANCE_TESTS OR
@@ -98,7 +100,6 @@ if (BUILD_UNIT_TESTS OR BUILD_PERFORMANCE_TESTS OR
             GIT_REPOSITORY https://github.com/catchorg/Catch2.git
             GIT_TAG        v3.6.0)
     FetchContent_MakeAvailable(Catch2)
-    find_package(TBB 2020 REQUIRED)
     enable_testing()
     add_subdirectory(tests)
 endif()

--- a/cmake/FetchTBB.cmake
+++ b/cmake/FetchTBB.cmake
@@ -1,0 +1,25 @@
+# Attempt to locate TBB 2020.
+# If not found, optionally fetch oneTBB via FetchContent and disable its tests.
+
+if(NOT DEFINED TBB_FETCH)
+  set(TBB_FETCH ON)
+endif()
+
+find_package(TBB 2020 QUIET)
+
+if(NOT TBB_FOUND)
+  if(TBB_FETCH)
+    message(STATUS "TBB not found; fetching oneTBB")
+    include(FetchContent)
+    # Disable oneTBB tests to speed up configuration
+    set(TBB_TEST OFF CACHE BOOL "" FORCE)
+    FetchContent_Declare(TBB
+      GIT_REPOSITORY https://github.com/oneapi-src/oneTBB.git
+      GIT_TAG v2021.12.0
+    )
+    FetchContent_MakeAvailable(TBB)
+  else()
+    message(FATAL_ERROR "TBB not found and automatic download disabled")
+  endif()
+endif()
+


### PR DESCRIPTION
## Summary
- allow automatically downloading oneTBB when not found
- expose `TBB_FETCH` option to disable fetching
- centralize TBB setup via `cmake/FetchTBB.cmake`

## Testing
- `cmake -S . -B build_fetch -G Ninja -DENABLE_MPI=OFF` *(fails: missing Object.hpp)*
- `cmake --build build_fetch` *(fails: missing Object.hpp)*
- `cmake -S . -B build_sys -G Ninja -DENABLE_MPI=OFF -DTBB_FETCH=OFF` *(fails: missing Object.hpp)*
- `cmake --build build_sys` *(fails: missing Object.hpp)*
