### PR TITLE
Use base traits for dual number detection

### DIFF
--- a/src/numeric/include/traits/ad_traits.h
+++ b/src/numeric/include/traits/ad_traits.h
@@ -3,40 +3,22 @@
 #ifndef NUMERIC_AD_TRAITS_H
 #define NUMERIC_AD_TRAITS_H
 
-#include "../base/dual_base.hpp"
-#include "type_traits.hpp"
-#include "numeric_traits.hpp"
+#include "../base/dual_base.h"
+#include "../base/traits_base.h"
+#include "type_traits.h"
+#include "numeric_traits.h"
 
 namespace fem::numeric::traits {
 
-        // Type traits for dual numbers
-        template<typename T>
-        struct is_dual : std::false_type {};
-
-        template<typename T, std::size_t N>
-        struct is_dual<autodiff::DualBase<T, N>> : std::true_type {};
-
-        template<typename T>
-        inline constexpr bool is_dual_v = is_dual<T>::value;
-
-        // Extract underlying scalar type
-        template<typename T>
-        struct scalar_type {
-            using type = T;
-        };
-
-        template<typename T, std::size_t N>
-        struct scalar_type<autodiff::DualBase<T, N>> {
-            using type = T;
-        };
-
-        template<typename T>
-        using scalar_type_t = typename scalar_type<T>::type;
+        using fem::numeric::is_dual_number;
+        using fem::numeric::is_dual_number_v;
+        using fem::numeric::scalar_type;
+        using fem::numeric::scalar_type_t;
 
         // Check if type supports dual arithmetic
         template<typename T>
         struct supports_dual_arithmetic {
-            static constexpr bool value = std::is_arithmetic_v<T> || is_dual_v<T>;
+            static constexpr bool value = std::is_arithmetic_v<T> || is_dual_number_v<T>;
         };
 
         template<typename T>


### PR DESCRIPTION
## Summary
- replace .hpp includes with existing .h headers
- use base traits for dual number type detection and scalar extraction
- add aliases for is_dual_number and scalar_type_t

## Testing
- `cmake -S . -B build` *(fails: Could NOT find MPI and missing src/algebra)*
