### PR TITLE
Relax element-wise operation detection

### DIFF
--- a/src/numeric/include/traits/operation_traits.h
+++ b/src/numeric/include/traits/operation_traits.h
@@ -99,16 +99,12 @@ namespace fem::numeric::traits {
      */
     template<typename Op>
     struct is_elementwise_operation {
-        static constexpr bool value = [] {
-            if constexpr (is_valid_operation_v<Op>) {
-                return operation_category_v<Op> == OperationCategory::Arithmetic ||
-                       operation_category_v<Op> == OperationCategory::Transcendental ||
-                       operation_category_v<Op> == OperationCategory::Comparison ||
-                       std::is_same_v<Op, ops::abs_op<>> ||
-                       std::is_same_v<Op, ops::sign_op<>>;
-            }
-            return false;
-        }();
+        static constexpr bool value =
+            operation_category_v<Op> == OperationCategory::Arithmetic ||
+            operation_category_v<Op> == OperationCategory::Transcendental ||
+            operation_category_v<Op> == OperationCategory::Comparison ||
+            std::is_same_v<Op, ops::abs_op<>> ||
+            std::is_same_v<Op, ops::sign_op<>>;
     };
 
     /**


### PR DESCRIPTION
## Summary
- Remove overly strict `is_valid_operation_v` guard in `is_elementwise_operation`
- Rely on operation categories so arithmetic and transcendental ops are detected even without argument types

## Testing
- `cmake -S src/numeric -B build-numeric` *(pass)*
- `cmake --build build-numeric` *(fail: invalid parameter type 'void')*
- `ctest --test-dir build-numeric` *(fail: missing test executables)*
