### PR TITLE
refactor: externalize dispatch strategy enum

### DIFF
--- a/src/numeric/tests/unit/traits/test_operation_traits.cpp
+++ b/src/numeric/tests/unit/traits/test_operation_traits.cpp
@@ -472,7 +472,7 @@ TEST(OperationTraitsTest, AccuracyRequirements) {
 
 // Test dispatch strategy
 TEST(OperationTraitsTest, DispatchStrategy) {
-    using Strategy = dispatch_strategy<ops::plus<>, double, 10>::Strategy;
+    using Strategy = DispatchStrategy;
 
     // Small size uses scalar
     EXPECT_EQ((dispatch_strategy<ops::plus<>, double, 10>::value), Strategy::Scalar);


### PR DESCRIPTION
## Summary
- move dispatch Strategy enumeration out of `dispatch_strategy` template as `DispatchStrategy`
- alias `DispatchStrategy` inside `dispatch_strategy`
- update tests to compare against `DispatchStrategy`

## Testing
- `cmake -S src/numeric -B build_numeric`
- `cmake --build build_numeric` *(fails: invalid parameter type 'void')*
