### PR TITLE
Fix mock types to satisfy numeric concept tests

### DIFF
--- a/src/numeric/include/traits/concepts.h
+++ b/src/numeric/include/traits/concepts.h
@@ -13,6 +13,7 @@
 #include "../base/storage_base.h"
 #include "../base/expression_base.h"
 #include "../base/iterator_base.h"
+#include "../base/broadcast_base.h"
 
 #include "type_traits.h"
 #include "numeric_traits.h"


### PR DESCRIPTION
## Summary
- include broadcast_base header in concepts
- extend mock autodiff, matrix, sparse matrix, and tensor types for concept compliance

## Testing
- `g++ -std=c++20 -Isrc/numeric/include -Isrc/numeric/tests/unit -pthread src/numeric/tests/unit/traits/test_concepts.cpp -lgtest -lgtest_main -o concept_tests && ./concept_tests >/tmp/test.log && tail -n 20 /tmp/test.log`
